### PR TITLE
cleanup qwerty

### DIFF
--- a/.config/keyd/default.conf
+++ b/.config/keyd/default.conf
@@ -29,8 +29,6 @@ n = k
 m = h
 
 [qwerty]
-esc = overload(switch, capslock)
-capslock = overload(extend, esc)
 e = e
 r = r
 t = t


### PR DESCRIPTION
esc and caps don't need to defined again since they're already in the `[main]` layout.